### PR TITLE
chore: remove obsolete copy step from production CI/CD workflow

### DIFF
--- a/.github/workflows/prod-cd.yml
+++ b/.github/workflows/prod-cd.yml
@@ -20,17 +20,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Copy compose file to server
-        uses: appleboy/scp-action@v0.1.7
-        with:
-          host: ${{ secrets.HOST }}
-          username: ${{ secrets.USERNAME }}
-          key: ${{ secrets.PRIVATE_KEY }}
-          port: 22
-          source: docker/docker-compose.server.yml
-          target: /apps/fe/ihsanmuh/
-          strip_components: 1
-
       - name: Deploy using SSH
         uses: appleboy/ssh-action@v1.0.3
         with:


### PR DESCRIPTION
- Eliminated the step that copied the Docker Compose file to the server in the production deployment workflow to streamline the process.